### PR TITLE
fix: update link for Pull Request tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ Here you will explain how other developers can contribute to your project. For e
 
 <h3>Documentations that might help</h3>
 
-[📝 How to create a Pull Request](https://www.atlassian.com/br/git/tutorials/making-a-pull-request)
+[📝 How to create a Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request)
 
 [💾 Commit pattern](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the URL for the "How to create a Pull Request" documentation link to correct a regional subdomain issue.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R166): Updated the URL for "How to create a Pull Request" to use the correct subdomain.